### PR TITLE
Fixed the problem of not able to disconnect after successful connection.

### DIFF
--- a/resources/lib/expressvpn.py
+++ b/resources/lib/expressvpn.py
@@ -1,0 +1,47 @@
+# This file is part of ExpressVPN For Kodi.
+
+#     ExpressVPN For Kodi is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+
+#     ExpressVPN For Kodi is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+
+#     You should have received a copy of the GNU General Public License
+#     along with ExpressVPN For Kodi.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+import subprocess
+import utils
+
+_utils = utils.Utils()
+
+class ExpressVPN:
+
+	def connect(self, server):
+		return subprocess.call(["expressvpn", "connect", server]) == 0
+	
+	def disconnect(self):
+		return subprocess.call(["expressvpn", "disconnect"]) == 0
+
+	def status(self):
+		return subprocess.check_output(["expressvpn", "status"])
+
+	def isConnected(self):
+                connected = False
+                ret = re.search("Connected\ to\ (.+)", self.status())
+                if ret is not None :
+                        connected = True
+                return connected
+
+	def currentServer(self):
+		return re.search("Connected\ to\ (.+)", self.status()).group(1) 
+
+	def serverList(self):
+		return subprocess.check_output("expressvpn list | awk '{gsub(/[\\t]+/,\"\t\")}1' | awk 'BEGIN {FS=\"\\t\"}; {print $1 \" - \" $2}'", shell = True)
+
+	def showUsage(self):
+		_utils.showTextviewer("Usage: expressvpn [ connect | disconnect | status | list ] [ server ]\n\nexpressvpn connect\nexpressvpn connect usny\nexpressvpn connect \"US - Chicago\"\nexpressvpn disconnect\nexpressvnp status\nexpressvpn list")

--- a/resources/lib/settings.py
+++ b/resources/lib/settings.py
@@ -1,0 +1,30 @@
+# This file is part of ExpressVPN For Kodi.
+
+#     ExpressVPN For Kodi is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+
+#     ExpressVPN For Kodi is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+
+#     You should have received a copy of the GNU General Public License
+#     along with ExpressVPN For Kodi.  If not, see <http://www.gnu.org/licenses/>.
+
+import xbmcaddon
+
+class Settings:
+	def __init__(self):
+		self.addon = xbmcaddon.Addon()
+
+	def __getitem__(self, key):
+		value = self.addon.getSetting(key)
+		if value.isdigit():
+			return int(value)
+		else:
+			return value
+
+	def open(self):
+		self.addon.openSettings()

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -1,0 +1,57 @@
+# This file is part of ExpressVPN For Kodi.
+
+#     ExpressVPN For Kodi is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+
+#     ExpressVPN For Kodi is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+
+#     You should have received a copy of the GNU General Public License
+#     along with ExpressVPN For Kodi.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import xbmc
+import xbmcaddon
+import xbmcgui
+
+class Utils:
+	def __init__(self):
+		self.addon = xbmcaddon.Addon()
+		self.addonName  = self.addon.getAddonInfo("name")
+		self.addonPath = self.addon.getAddonInfo("path")
+		self.iconPath = xbmc.translatePath("%s/%s" % (self.addonPath, "resources/icon.png"))
+		self.failedIconPath = "DefaultIconError.png"
+
+	def getArgC(self):
+		return len(sys.argv)
+
+	def getArgV(self, index):
+		return sys.argv[index]
+
+	def getString(self, id):
+		return self.addon.getLocalizedString(id)
+
+	def showTextviewer(self, text):
+		xbmcgui.Dialog().textviewer(self.addonName, text)
+
+	def showOK(self, heading, line1, line2 = "" , line3 = ""):
+		xbmcgui.Dialog().ok(heading, line1, line2, line3)
+
+	def showYesNo(self, heading, line1, line2 = "", line3 = "", nolabel = "No", yeslabel = "Yes"):
+		return xbmcgui.Dialog().yesno(heading, line1, line2, line3, nolabel, yeslabel) == 1
+
+	def showSelect(self, heading, list):
+		return xbmcgui.Dialog().select(heading, list)
+
+	def showNotification(self, text, success = True):
+		if success:
+			image = self.iconPath
+		else:
+			image = self.failedIconPath
+			
+		command = 'Notification(%s, %s, %s, %s)' % (self.addonName, text, 5000, image)
+		xbmc.executebuiltin(command)


### PR DESCRIPTION
The problem of not able to disconnect is due to the function isConnected() always returning false when checking the connection status. Thus it is not able to get into the code snippet of disconnecting from the VPN.

The function isConnected() always return false is because it is looking for string 'Connected to' in the start of the line. However, there are leading ASCII colour characters in ExpressVPN Linux client version 2.4.4.19 (expressvpn_2.4.4.19-1_amd64.deb). Thus it fails and always return false.
It is now eliminated by using regular expression to look for the pattern rather than looking for it at the start of the line.